### PR TITLE
Add file-header-path option

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=duplicate-code, # pylint-file-header: Fails in unit tests
         missing-docstring, # pylint-file-header: Add DOCSTRINGS only where helpful
         relative-import, # pylint-file-header: ignore for unit tests
         redefined-outer-name, # pylint-file-header: conflicts with pytest fixtures
-        too-few-public-methods # pylint-file-header: know what you are doing
+        too-few-public-methods, # pylint-file-header: know what you are doing
+        bad-option-value # pylint-file-header: conflict with super-with-arguments in py34
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ When the `file-header` setting is omitted, pylint will pass.
 * `file-header-path` is the path to the file that contains the header. This is useful in case of long, multi-line headers, such as copyrights.
 * `file-header-ignore-empty-files` turns on the mode of ignoring the empty files, like `__init__.py`. The default value is `False`.
 
+If both options `file-header` and `file-header-path` are set, then `file-header` will be used and the `file-header-path` is ignored.
+
 ## Example
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Generate a `.pylintrc` file by executing `pylint --generate-rcfile`.
 Then add `pylintfileheader` to the plugins to load and set the `file-header` option to the [regular expression](https://docs.python.org/3/library/re.html#regular-expression-syntax) that the file header should match.  
 When the `file-header` setting is omitted, pylint will pass.
 
+### Options
+
+* `file-header` is a regexp representing the file header that should be on top of a file.
+* `file-header-path` is the path to the file that contains the header. This is useful in case of long, multi-line headers, such as copyrights.
 * `file-header-ignore-empty-files` turns on the mode of ignoring the empty files, like `__init__.py`. The default value is `False`.
 
 ## Example

--- a/pylintfileheader/file_header_checker.py
+++ b/pylintfileheader/file_header_checker.py
@@ -57,6 +57,7 @@ class FileHeaderChecker(BaseChecker):
     )
 
     def __init__(self, linter=None):
+        # pylint: disable=super-with-arguments
         super(FileHeaderChecker, self).__init__(linter=linter)
         self.pattern = None
         self.header = None
@@ -64,8 +65,8 @@ class FileHeaderChecker(BaseChecker):
     def open(self):
         self.header = self.config.file_header
         if not self.header and self.config.file_header_path:
-            with open(self.config.file_header_path, 'r') as f:
-                self.header = f.read()
+            with open(self.config.file_header_path, 'r') as header_file:
+                self.header = header_file.read()
 
         if self.header:
             if sys.version_info[0] < 3:

--- a/pylintfileheader/file_header_checker.py
+++ b/pylintfileheader/file_header_checker.py
@@ -37,6 +37,15 @@ class FileHeaderChecker(BaseChecker):
             }
         ),
         (
+            'file-header-path',
+            {
+                'default': None,
+                'type': 'string',
+                'metavar': '<file>',
+                'help': 'The path to the file that contains the header.',
+            }
+        ),
+        (
             'file-header-ignore-empty-files',
             {
                 'default': False,
@@ -47,27 +56,39 @@ class FileHeaderChecker(BaseChecker):
         ),
     )
 
+    def __init__(self, linter=None):
+        super(FileHeaderChecker, self).__init__(linter=linter)
+        self.pattern = None
+        self.header = None
+
+    def open(self):
+        self.header = self.config.file_header
+        if not self.header and self.config.file_header_path:
+            with open(self.config.file_header_path, 'r') as f:
+                self.header = f.read()
+
+        if self.header:
+            if sys.version_info[0] < 3:
+                opts = re.LOCALE | re.MULTILINE
+            else:
+                opts = re.MULTILINE
+            self.pattern = re.compile(r'\A' + self.header, opts)
+
     def process_module(self, node):
         """Process the astroid node stream."""
-        if self.config.file_header:
-            content = None
-            with node.stream() as stream:
-                # Explicit decoding required by python 3
-                content = stream.read().decode('utf-8')
 
-            if self.config.file_header_ignore_empty_files and not content:
-                return
+        if self.pattern is None:
+            return
 
-            if sys.version_info[0] < 3:
-                pattern = re.compile(
-                    r'\A' + self.config.file_header, re.LOCALE | re.MULTILINE)
-            else:
-                # The use of re.LOCALE is discouraged in python 3
-                pattern = re.compile(
-                    r'\A' + self.config.file_header, re.MULTILINE)
+        content = None
+        with node.stream() as stream:
+            # Explicit decoding required by python 3
+            content = stream.read().decode('utf-8')
 
-            matches = pattern.findall(content)
+        if self.config.file_header_ignore_empty_files and not content:
+            return
 
-            if len(matches) != 1:
-                self.add_message('invalid-file-header', 1,
-                                 args=self.config.file_header)
+        matches = self.pattern.findall(content)
+
+        if len(matches) != 1:
+            self.add_message('invalid-file-header', 1, args=self.header)

--- a/pylintfileheadertest/file_header_checker_test.py
+++ b/pylintfileheadertest/file_header_checker_test.py
@@ -4,8 +4,13 @@
 # ---------------------------------------------------------------------------------------------
 
 # pylint: disable=invalid-name,unused-variable
+import re
+import sys
+
 from mock import MagicMock
 import pylint.testutils
+import pytest
+
 from pylintfileheader.file_header_checker import FileHeaderChecker
 
 
@@ -71,13 +76,49 @@ class TestFileHeaderCheckerNoConfig(pylint.testutils.CheckerTestCase):
     def test_no_message_added(self):
         """When the `file-header` option is not set, no message should be added."""
 
-        self.checker.config.file_header = None
         node_mock = MagicMock()
         node_mock.stream.return_value.__enter__.return_value.read.return_value.decode.return_value = '# Invalid\n# Header'
         with self.assertNoMessages():
             self.checker.process_module(node_mock)
 
 
-class TestFileHeaderCheckerPath(TestFileHeaderChecker):
+class TestFileHeaderCheckerPathMain(TestFileHeaderChecker):
     CHECKER_CLASS = FileHeaderChecker
     CONFIG = {'file_header_path': 'pylintfileheadertest/header.txt'}
+
+
+class TestFileHeaderCheckerPathExtra:
+    CHECKER_CLASS = FileHeaderChecker
+
+    def get_checker(self, config):
+        linter = pylint.testutils.UnittestLinter()
+        checker = self.CHECKER_CLASS(linter)
+        for key, value in config.items():
+            setattr(checker.config, key, value)
+        return checker
+
+    def test_incorrect_regex(self):
+        with pytest.raises(re.error):
+            self.get_checker({
+                'file_header': '.+)',
+            }).open()
+
+    def test_wrong_path(self):
+        if sys.version_info[0] < 3:
+            excp = IOError
+        else:
+            excp = FileNotFoundError
+
+        with pytest.raises(excp):
+            self.get_checker({
+                'file_header_path': 'foo-bar.txt',
+            }).open()
+
+    def test_both_options(self):
+        # no error expected since the file_header is used
+        checker = self.get_checker({
+            'file_header': '# Valid\n# Header',
+            'file_header_path': 'foo-bar.txt',
+        })
+        checker.open()
+        assert checker.header == '# Valid\n# Header'

--- a/pylintfileheadertest/file_header_checker_test.py
+++ b/pylintfileheadertest/file_header_checker_test.py
@@ -43,15 +43,6 @@ class TestFileHeaderChecker(pylint.testutils.CheckerTestCase):
                 args='# Valid\n# Header')):
             self.checker.process_module(node_mock)
 
-    def test_config_empty_no_message_added(self):
-        """When the `file-header` option is not set, no message should be added."""
-
-        self.checker.config.file_header = None
-        node_mock = MagicMock()
-        node_mock.stream.return_value.__enter__.return_value.read.return_value.decode.return_value = '# Invalid\n# Header'
-        with self.assertNoMessages():
-            self.checker.process_module(node_mock)
-
     def test_ignore_empty_files(self):
         """When the `file-header-ignore-empty-files` option is set to True."""
 
@@ -71,3 +62,22 @@ class TestFileHeaderChecker(pylint.testutils.CheckerTestCase):
                 line=1,
                 args='# Valid\n# Header')):
             self.checker.process_module(node_mock)
+
+
+class TestFileHeaderCheckerNoConfig(pylint.testutils.CheckerTestCase):
+    CHECKER_CLASS = FileHeaderChecker
+    CONFIG = {}
+
+    def test_no_message_added(self):
+        """When the `file-header` option is not set, no message should be added."""
+
+        self.checker.config.file_header = None
+        node_mock = MagicMock()
+        node_mock.stream.return_value.__enter__.return_value.read.return_value.decode.return_value = '# Invalid\n# Header'
+        with self.assertNoMessages():
+            self.checker.process_module(node_mock)
+
+
+class TestFileHeaderCheckerPath(TestFileHeaderChecker):
+    CHECKER_CLASS = FileHeaderChecker
+    CONFIG = {'file_header_path': 'pylintfileheadertest/header.txt'}

--- a/pylintfileheadertest/header.txt
+++ b/pylintfileheadertest/header.txt
@@ -1,0 +1,2 @@
+# Valid
+# Header


### PR DESCRIPTION
Use a file to store a long multi-line header instead of putting it to the pylint config.
