### PR TITLE
Support for pylint 4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 codecov
 mock
-pylint>=3.0,<4.0
+pylint>=3.0,<5.0
 pylint-quotes
 pylintfileheader>=1.0.0
 pytest

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='Leo Hanisch',
     license='MIT',
     package_data={'pylintfileheader': ['ThirdPartyNotices.txt']},
-    install_requires=['pylint>=3.0,<4.0'],
+    install_requires=['pylint>=3.0,<5.0'],
     project_urls={
         'Source': 'https://github.com/HaaLeo/pylint-file-header',
         'Issue Tracker': 'https://github.com/HaaLeo/pylint-file-header/issues',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ]
 )


### PR DESCRIPTION
Hey @HaaLeo, 

I adjusted the version constraints on pylint.
I then tested the installed plugin with pylint version 4.04 and the plugin still works just as expected.

I also added the pypi classifiers for the new python3 versions that this plugin supports.

Resolves #7 